### PR TITLE
HS-3 - Adding service principal Contributor role to the Container

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,7 +1,7 @@
 name: Terraform Workflow
 
 on:
-  workflow_dispatch: # Manually trigger this workflow
+  workflow_dispatch:
     inputs:
       action:
         description: 'Terraform action for DEVELOPMENT environment (plan, apply, destroy). Default is plan.'
@@ -15,19 +15,22 @@ on:
         default: 'plan'
   push:
     branches:
-      - 'feature/**' # Trigger on push to branches like feature/new-thing
-      - 'master'       # Trigger plan (and then manual apply) on push to master
+      - 'feature/**'
+      - 'master'
+
+env:
+  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  TF_VAR_ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  TF_VAR_vm_ssh_public_key: ${{ secrets.TF_VM_SSH_PUBLIC_KEY }}
 
 jobs:
   validate_on_feature_push:
     name: Validate on Feature Branch Push
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/feature/') # Only run for push to feature/*
-    env: # Define common environment variables for Azure auth for this job, if init needs them
-      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -47,11 +50,6 @@ jobs:
     name: Manual Terraform Actions (Development Env)
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' # Only run this job for manual dispatch
-    env: # Define common environment variables for Azure auth for this job
-      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -92,10 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     env:
-      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      TF_LOG: DEBUG # Only add job-specific env if needed
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -116,15 +111,10 @@ jobs:
           path: tfplan-master
           retention-days: 7
 
-  destroy_plan_for_master:
-    name: Show Destroy Plan for Master Branch
+  create_destroy_plan_for_master:
+    name: Create and Upload Destroy Plan for Master
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
-    env:
-      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -138,19 +128,20 @@ jobs:
         run: terraform plan -destroy -out=tfdestroyplan-master
       - name: Show Destroy Plan
         run: terraform show -no-color tfdestroyplan-master
+      - name: Upload Destroy Plan Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfdestroyplan-master-artifact
+          path: tfdestroyplan-master
+          retention-days: 7
 
   apply_for_master:
     name: Apply for Master Branch (Requires Approval)
     runs-on: ubuntu-latest
-    needs: [plan_for_master] # Ensures this job runs after plan_for_master and destroy_plan_for_master
+    needs: [plan_for_master]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' # Ensures it only runs for master pushes
     environment:
       name: production
-    env:
-      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -172,14 +163,10 @@ jobs:
   destroy_apply_for_master:
     name: Destroy Apply for Master Branch (Requires Approval)
     runs-on: ubuntu-latest
+    needs: [create_destroy_plan_for_master]
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
     environment:
       name: production
-    env:
-      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,3 @@
+data "azuread_service_principal" "terraform" {
+  client_id = var.ARM_CLIENT_ID  
+}

--- a/main.tf
+++ b/main.tf
@@ -16,3 +16,9 @@ resource "azurerm_storage_container" "terraform-storage-accounts" {
   storage_account_name  = azurerm_storage_account.terraform-storage-accounts.name
   container_access_type = "private"
 }
+
+resource "azurerm_role_assignment" "sp_tfstate_blob_access" {
+  principal_id         = data.azuread_service_principal.terraform.object_id
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = azurerm_storage_account.terraform-storage-accounts.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,8 @@ variable storage_account_name {
 variable location {
     default = "westeurope"
 }
+variable "ARM_CLIENT_ID" {
+  description = "Azure Client ID"
+  type        = string
+  # No default; set via TF_VAR_ARM_CLIENT_ID environment variable or tfvars file
+}


### PR DESCRIPTION
This pull request introduces several updates to the Terraform workflow configuration and associated Terraform files. The main changes include centralizing environment variables for Azure authentication, improving artifact handling in the destroy plan workflow, and adding new resources to enhance Azure role assignments.

### Workflow Configuration Updates:
* Centralized Azure authentication environment variables (`ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, etc.) at the workflow level instead of duplicating them across individual jobs in `.github/workflows/terraform.yaml`. [[1]](diffhunk://#diff-5125e64cb591a598774a1b20f8fee8e4551204441592cbbbf523b9eb9c10cf3eL18-L30) [[2]](diffhunk://#diff-5125e64cb591a598774a1b20f8fee8e4551204441592cbbbf523b9eb9c10cf3eL50-L54) [[3]](diffhunk://#diff-5125e64cb591a598774a1b20f8fee8e4551204441592cbbbf523b9eb9c10cf3eL95-R93)
* Renamed the `destroy_plan_for_master` job to `create_destroy_plan_for_master` and added an artifact upload step to save the destroy plan as an artifact. [[1]](diffhunk://#diff-5125e64cb591a598774a1b20f8fee8e4551204441592cbbbf523b9eb9c10cf3eL119-L127) [[2]](diffhunk://#diff-5125e64cb591a598774a1b20f8fee8e4551204441592cbbbf523b9eb9c10cf3eR131-L153)
* Updated dependencies between jobs to reflect the new `create_destroy_plan_for_master` job.

### Terraform File Enhancements:
* Added a new `azuread_service_principal` data block in `data.tf` to fetch the Azure service principal object ID dynamically.
* Introduced a new `azurerm_role_assignment` resource in `main.tf` to assign the "Storage Blob Data Contributor" role to the service principal for accessing storage account blobs.
* Declared a new `ARM_CLIENT_ID` variable in `variables.tf` for better parameterization and to align with the centralized environment variable setup.